### PR TITLE
Change itamae version to 1.2

### DIFF
--- a/itamae-plugin-recipe-nodebrew.gemspec
+++ b/itamae-plugin-recipe-nodebrew.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "itamae", "~> 1.2.21"
+  spec.add_dependency "itamae", "~> 1.2"
 
   spec.add_development_dependency "bundler", "~> 1.10.5"
   spec.add_development_dependency "rake", "~> 10.4.2"


### PR DESCRIPTION
Dependence on itamae has been set to >~ 1.2.21, so that itamae newer than 1.2.x could not be used.
